### PR TITLE
Correctly 'continue' requests

### DIFF
--- a/lib/mwapi.js
+++ b/lib/mwapi.js
@@ -16,7 +16,7 @@ module.exports.MWApiError = MWApiError;
  * @constructor
  */
 function MWApi(userAgent, apiUrl) {
-    this.options = {
+    this.origOptions = {
         uri: apiUrl,
         headers: {'User-Agent': userAgent}
     };
@@ -30,7 +30,7 @@ function MWApi(userAgent, apiUrl) {
  */
 MWApi.prototype.execute = function execute(request, options) {
     var self = this,
-        reqObj = extend(this.options);
+        reqObj = Object.create(this.origOptions);
 
     // Convert arrays to pipe-separated strings:  ['a','b'] ==> 'a|b'
     for (var key in request) {


### PR DESCRIPTION
'preq' modifies the request object passed to it. This results in
'this.options' also getting modified as 'extend',

    "Extends one object (the target object. Here, 'this .options')
     with one or more others, returning the modified object."

Creating the request object from the modified 'this.options' property
in the successive requests results in the query not continuing as it should.

So create a request object with a copy of 'this.options' and thus continuing
the query as it actually should.